### PR TITLE
Add sample function

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -153,6 +153,34 @@ The logger provides the eight logging levels defined in [RFC 5424](http://tools.
     Log::info($error);
     Log::debug($error);
 
+Sample function with try-catch statement and the logger is the following:
+
+    /**
+     * Get an array of all student profiles
+     *
+     * @param  string   $sql
+     * @return Success  an array of all student profiles
+     *         Fail     an empty array
+     */
+    public function getAllProfiles($sql)
+    {
+        try
+        {
+            $results = DB::select($sql);
+            Log::info("It successed to execute the select statement.");
+
+            return $results;
+        }
+        catch(\Exception $e)
+        {
+            Log::error("It failed to execute the select statement.\n" .
+                        "The SQL is " . $sql . "\n" .
+                        "The occured exception is " . $e);
+
+            return array();
+        }
+    }
+
 #### Contextual Information
 
 An array of contextual data may also be passed to the log methods. This contextual data will be formatted and displayed with the log message:


### PR DESCRIPTION
When trying detecting exception by using try-catch statement, it failed in case of setting “Exception $e” as a parameter. However, it works case of setting “\Exception $e”. 

It isn’t easy to realize the cause. So, this sample function will be needed as a example of combination of try-catch and the logger.